### PR TITLE
Adding functionality to skip non @flow annotated files

### DIFF
--- a/playground/src/app.tsx
+++ b/playground/src/app.tsx
@@ -59,7 +59,8 @@ const defaultOptions: Options = {
   bracketSpacing: false,
   arrowParens: "avoid",
   printWidth: 80,
-  inlineUtilityTypes: false
+  inlineUtilityTypes: false,
+  skipNonFlow: false
 };
 
 class App extends React.Component<Props, State> {

--- a/playground/src/options-panel.tsx
+++ b/playground/src/options-panel.tsx
@@ -27,6 +27,7 @@ export type Options = {
   arrowParens: "avoid" | "always";
   printWidth: number;
   inlineUtilityTypes: boolean;
+  skipNonFlow: boolean;
 };
 
 type Props = {

--- a/src/cli.js
+++ b/src/cli.js
@@ -46,7 +46,8 @@ const cli = argv => {
     )
     .option("--print-width [width]", "line width (depends on --prettier)", 80)
     .option("--write", "write output to disk instead of STDOUT")
-    .option("--delete-source", "delete the source file");
+    .option("--delete-source", "delete the source file")
+    .option("--skip-non-flow", "This skips all the files which are not annotated by @flow");
 
   program.parse(argv);
 
@@ -64,7 +65,8 @@ const cli = argv => {
     trailingComma: program.trailingComma,
     bracketSpacing: Boolean(program.bracketSpacing),
     arrowParens: program.arrowParens,
-    printWidth: parseInt(program.printWidth)
+    printWidth: parseInt(program.printWidth),
+    skipNonFlow: Boolean(program.skipNonFlow)
   };
 
   const files = new Set();
@@ -80,6 +82,9 @@ const cli = argv => {
 
     try {
       const outCode = convert(inCode, options);
+      if (typeof outCode === 'object' && outCode.skip) {
+        console.log(`skipping file: ${file} as it's not @flow prefixed`);
+      }
 
       if (program.write) {
         const extension = detectJsx(inCode) ? ".tsx" : ".ts";

--- a/src/convert.js
+++ b/src/convert.js
@@ -29,11 +29,19 @@ const convert = (flowCode, options) => {
     startLine: {},
     endLine: {}
   };
+  let skip = true;
   for (const comment of ast.comments) {
+    if (comment.value.trim() === '@flow') {
+      skip = false;
+    }
     comments.startLine[comment.loc.start.line] = comment;
     comments.endLine[comment.loc.end.line] = comment;
   }
 
+  // Skipping file if it is not @flow prefixed
+  if (options && options.skipNonFlow && skip){
+    return {skip};
+  }
   // apply our transforms, traverse mutates the ast
   const state = {
     usedUtilityTypes: new Set(),

--- a/src/transform.js
+++ b/src/transform.js
@@ -110,6 +110,7 @@ const QualifiedReactTypeNameMap = {
 const transform = {
   Program: {
     enter(path, state) {
+      debugger;
       const { body } = path.node;
 
       for (let i = 0; i < body.length; i++) {

--- a/src/transform.js
+++ b/src/transform.js
@@ -110,7 +110,6 @@ const QualifiedReactTypeNameMap = {
 const transform = {
   Program: {
     enter(path, state) {
-      debugger;
       const { body } = path.node;
 
       for (let i = 0; i < body.length; i++) {

--- a/test/fixtures/convert/formatting/prettier_options/options.json
+++ b/test/fixtures/convert/formatting/prettier_options/options.json
@@ -3,5 +3,6 @@
     "semi": false,
     "singleQuote": true,
     "tabWidth": 4,
-    "trailingComma": "all"
+    "trailingComma": "all",
+    "skipNonFlow": false
 }


### PR DESCRIPTION
Adding functionality to skip non @flow annotated files

Use flag --skip-non-flow to enable this 
It will skip the files not annotated with @flow